### PR TITLE
Create BoardApi module

### DIFF
--- a/src/Catan.jl
+++ b/src/Catan.jl
@@ -1,22 +1,8 @@
 module Catan
 include("main.jl")
 
-export DefaultRobotPlayer, RobotPlayer, Player, Board, PlayerType, PlayerPublicView, Game,
-    initialize_and_do_game!
-
-# Additionally used for testing
-export get_coord_from_human_tile_description,
-get_road_coords_from_human_tile_description,
-get_neighbors,
-read_map,
-load_gamestate!,
-reset_savefile,
-random_sample_resources,
-add_devcard,
-play_devcard,
-assign_largest_army!,
-get_total_vp_count,
-add_port,
+export DefaultRobotPlayer, RobotPlayer, Player, Board, Road, PlayerType, PlayerPublicView, Game,
+    initialize_and_do_game!,
 BoardApi
 
 # Player methods to implement

--- a/src/Catan.jl
+++ b/src/Catan.jl
@@ -10,7 +10,14 @@ get_road_coords_from_human_tile_description,
 get_neighbors,
 read_map,
 load_gamestate!,
-reset_savefile
+reset_savefile,
+random_sample_resources,
+add_devcard,
+play_devcard,
+assign_largest_army!,
+get_total_vp_count,
+add_port,
+BoardApi
 
 # Player methods to implement
 export choose_accept_trade,
@@ -28,7 +35,8 @@ choose_card_to_steal,
 
 PLAYER_ACTIONS,
 MAX_SETTLEMENT,
-MAX_CITY
+MAX_CITY,
+MAX_ROAD
 
 game = nothing
 println(ARGS)

--- a/src/Catan.jl
+++ b/src/Catan.jl
@@ -26,7 +26,7 @@ MAX_ROAD
 
 game = nothing
 println(ARGS)
-reset_savefile("game_$(Dates.format(now(), "HHMMSS")).txt")
+#reset_savefile("game_$(Dates.format(now(), "HHMMSS")).txt")
 
 function run(args)
     if length(args) >= 1

--- a/src/Catan.jl
+++ b/src/Catan.jl
@@ -4,6 +4,14 @@ include("main.jl")
 export DefaultRobotPlayer, RobotPlayer, Player, Board, PlayerType, PlayerPublicView, Game,
     initialize_and_do_game!
 
+# Additionally used for testing
+export get_coord_from_human_tile_description,
+get_road_coords_from_human_tile_description,
+get_neighbors,
+read_map,
+load_gamestate!,
+reset_savefile
+
 # Player methods to implement
 export choose_accept_trade,
 choose_building_location,
@@ -16,10 +24,15 @@ choose_road_location,
 choose_robber_victim,
 choose_who_to_trade_with,
 choose_year_of_plenty_resources,
-choose_card_to_steal
+choose_card_to_steal,
+
+PLAYER_ACTIONS,
+MAX_SETTLEMENT,
+MAX_CITY
 
 game = nothing
 println(ARGS)
+reset_savefile("game_$(Dates.format(now(), "HHMMSS")).txt")
 
 function run(args)
     if length(args) >= 1
@@ -39,11 +52,13 @@ function run(args, PLAYERS)
     end
     if length(args) >= 3
         SAVEFILE = args[3]
+        reset_savefile(SAVEFILE)
+
         if SAVE_GAME_TO_FILE
             global SAVEFILEIO = open(SAVEFILE, "a")
         end
     else
-        SAVEFILE = "./data/savefile.txt"
+        reset_savefile("./data/savefile.txt")
         io = open(SAVEFILE, "w")
         write(io,"")
         close(io)
@@ -58,11 +73,11 @@ end
 function run(players::Vector{PlayerType})
     game = Game(players)
     MAPFILE = generate_random_map("_temp_map_file.csv")
-    SAVEFILE = "./data/savefile.txt"
-    io = open(SAVEFILE, "w"); write(io,""); close(io)
-    if SAVE_GAME_TO_FILE
-        global SAVEFILEIO = open(SAVEFILE, "a")
-    end
+    reset_savefile("./data/savefile.txt")
+    #SAVEFILE = "./data/savefile.txt"
+    #if SAVE_GAME_TO_FILE
+    #    global SAVEFILEIO = open(SAVEFILE, "a")
+    #end
     initialize_and_do_game!(game, MAPFILE, SAVEFILE)
 end
 

--- a/src/apis/README.md
+++ b/src/apis/README.md
@@ -2,5 +2,5 @@
 
 Here we store all the methods used to:
 * Manipulate data stored in board, game, or players
-* Helper methods to do read-only operations on these three structs (these are preferred to raw access to fields of board, game, or players.
+* Helper methods to do read-only operations on these three structs (these are preferred to raw access to fields of board, game, or players.)
 

--- a/src/apis/board_api.jl
+++ b/src/apis/board_api.jl
@@ -15,6 +15,11 @@ count_victory_points_from_board(board)
 harvest_resource(board::Board, team::Symbol, resource::Symbol, quantity::Int)
 """
 
+module BoardApi
+#import Catan: Board, Road
+using ..Catan: Board, Road
+include("../constants.jl")
+include("../board.jl")
 macro api_name(x)
     API_DICTIONARY[string(x)] = x
 end
@@ -33,6 +38,11 @@ function count_cities(board, team)
     return length(get_city_locations(board, team))
 end
 
+function print_board_stats(board::Board, team::Symbol)
+    @info "$(count_roads(board, team)) roads"
+    @info "$(count_settlements(board, team)) settlements"
+    @info "$(count_cities(board, team)) cities"
+end
 
 function get_building_locations(board, team::Symbol)::Vector{Tuple}
     [c for (c,b) in board.coord_to_building if b.team == team]
@@ -379,4 +389,4 @@ function get_admissible_road_locations(board::Board, team::Symbol, is_first_turn
     end
     return road_coords
 end
-
+end

--- a/src/apis/board_api.jl
+++ b/src/apis/board_api.jl
@@ -17,7 +17,7 @@ harvest_resource(board::Board, team::Symbol, resource::Symbol, quantity::Int)
 
 module BoardApi
 #import Catan: Board, Road
-using ..Catan: Board, Road
+using ..Catan: Board, Building, Road, log_action
 include("../constants.jl")
 include("../board.jl")
 macro api_name(x)

--- a/src/apis/board_api.jl
+++ b/src/apis/board_api.jl
@@ -16,7 +16,6 @@ harvest_resource(board::Board, team::Symbol, resource::Symbol, quantity::Int)
 """
 
 module BoardApi
-#import Catan: Board, Road
 using ..Catan: Board, Building, Road, log_action
 include("../constants.jl")
 include("../board.jl")

--- a/src/apis/board_api.jl
+++ b/src/apis/board_api.jl
@@ -16,9 +16,10 @@ harvest_resource(board::Board, team::Symbol, resource::Symbol, quantity::Int)
 """
 
 module BoardApi
-using ..Catan: Board, Building, Road, log_action
-include("../constants.jl")
+using ..Catan: Board, Building, Road, log_action, 
+MAX_ROAD, MAX_SETTLEMENT, MAX_CITY, DIMS, COORD_TO_TILES, VP_AWARDS
 include("../board.jl")
+
 macro api_name(x)
     API_DICTIONARY[string(x)] = x
 end

--- a/src/apis/board_api.jl
+++ b/src/apis/board_api.jl
@@ -229,8 +229,35 @@ end
 
 
 
-
+#
 # Construction validation
+#
+
+"""
+    `get_admissible_settlement_locations(board, team::Symbol, first_turn = false)::Vector{Tuple{Int,Int}}`
+
+Returns a vector of all legal locations to place a settlement:
+1. Always respect the distance-from-other-buildings rule (most not be neighboring another city or settlement)
+2. Must not exceed `MAX_SETTLEMENT`
+3. If it's not the first turn, it must be adjacent to a road of the same team
+"""
+function get_admissible_settlement_locations(board, team::Symbol, first_turn = false)::Vector{Tuple{Int,Int}}
+
+    # Some quick checks to eliminate most spaces
+    if count_settlements(board, team) >= MAX_SETTLEMENT
+        return []
+    end
+    coords_near_player_road = get_road_locations(board, team)
+    empty = get_empty_spaces(board)
+    if first_turn
+        admissible = empty
+    else
+        admissible = intersect(empty, coords_near_player_road)
+    end
+    
+    # More complex check after we've done the first filtration
+    return filter(c -> is_valid_settlement_placement(board, team, c, first_turn), admissible)
+end
 
 function is_valid_settlement_placement(board, team, coord, is_first_turn::Bool = false)::Bool
     if coord == nothing
@@ -279,6 +306,13 @@ function is_valid_city_placement(board, team, coord)::Bool
     return false
 end
 
+function get_admissible_city_locations(board, team::Symbol)::Vector{Tuple{Int,Int}}
+    if count_cities(board, team) >= MAX_CITY
+        return []
+    end
+    get_settlement_locations(board, team)
+end
+
 function is_valid_road_placement(board, team::Symbol, coord1, coord2)::Bool
     if coord1 == nothing || coord2 == nothing
         return false
@@ -315,5 +349,34 @@ function is_valid_road_placement(board, team::Symbol, coord1, coord2)::Bool
         @debug "[Invalid road] never found a valid neighbor"
     end
     return found_neighbor
+end
+
+function get_admissible_road_locations(board::Board, team::Symbol, is_first_turn = false)::Vector{Vector{Tuple{Int,Int}}}
+    if count_roads(board, team) >= MAX_ROAD
+        return []
+    end
+    start_coords = []
+    coords_near_player_road = get_road_locations(board, team)
+    coords_near_player_buildings = get_building_locations(board, team)
+
+    # This is because on the first turn (placement of first 2 settlements), the 
+    # second road must be attached to the second settlement
+    if is_first_turn
+        filter!(c -> !(c in coords_near_player_road), coords_near_player_buildings)
+    else 
+        append!(start_coords, coords_near_player_road)
+    end
+    append!(start_coords, coords_near_player_buildings)
+    start_coords = Set(unique(start_coords))
+    road_coords = []
+    for c in start_coords
+        ns = get_neighbors(c)
+        for n in ns
+            if is_valid_road_placement(board, team, c, n)
+                push!(road_coords, [c,n])
+            end
+        end
+    end
+    return road_coords
 end
 

--- a/src/apis/player_api.jl
+++ b/src/apis/player_api.jl
@@ -61,7 +61,7 @@ function get_total_vp_count(board, player::Player)
     return get_public_vp_count(board, player) + get_vp_count_from_dev_cards(player)
 end
 function get_public_vp_count(board, player::Player)
-    points = count_victory_points_from_board(board, player.team)
+    points = BoardApi.count_victory_points_from_board(board, player.team)
     if player.has_largest_army
         points += 2
     end

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -16,7 +16,16 @@ MAX_CITY = 4
 MAX_SETTLEMENT = 5
 MAX_ROAD = 14
 
-SAVEFILE = "game_$(Dates.format(now(), "HHMMSS")).txt"
+function reset_savefile(path)
+    global SAVEFILE = path
+
+    if true #SAVE_GAME_TO_FILE
+        io = open(SAVEFILE, "w"); write(io,""); close(io)
+        global SAVEFILEIO = open(SAVEFILE, "a")
+    end
+    return SAVEFILE, SAVEFILEIO
+end
+
 VP_AWARDS = Dict([
                   :Settlement => 1,
                   :City => 2,

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -23,10 +23,10 @@ end
 function reset_savefile(path)
     global SAVEFILE = path
 
-    if true #SAVE_GAME_TO_FILE
+    if SAVE_GAME_TO_FILE
         io = open(SAVEFILE, "w"); write(io,""); close(io)
-        global SAVEFILEIO = open(SAVEFILE, "a")
     end
+    global SAVEFILEIO = open(SAVEFILE, "a")
     return SAVEFILE, SAVEFILEIO
 end
 

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -16,6 +16,10 @@ MAX_CITY = 4
 MAX_SETTLEMENT = 5
 MAX_ROAD = 14
 
+function reset_savefile(path, io)
+    global SAVEFILE = path
+    global SAVEFILEIO = io
+end
 function reset_savefile(path)
     global SAVEFILE = path
 

--- a/src/main.jl
+++ b/src/main.jl
@@ -126,18 +126,18 @@ end
 # For now, we can just keep player input unvalidated to ensure smoother gameplay
 function construct_city(board, player::Player, coord)
     pay_construction(player, :City)
-    build_city(board, player.team, coord)
+    BoardApi.build_city(board, player.team, coord)
 end
 function construct_settlement(board, player::Player, coord)
     pay_construction(player, :Settlement)
     if haskey(board.coord_to_port, coord)
         add_port(player, board.coord_to_port[coord])
     end
-    build_settlement(board, player.team, coord)
+    BoardApi.build_settlement(board, player.team, coord)
 end
 function construct_road(board, player::Player, coord1, coord2)
     pay_construction(player, :Road)
-    build_road(board, player.team, coord1, coord2)
+    BoardApi.build_road(board, player.team, coord1, coord2)
 end
 
 function pay_construction(player::Player, construction::Symbol)
@@ -276,7 +276,7 @@ end
 
 function do_knight_action(board, players::Vector{PlayerType}, player)
     players_public = [PlayerPublicView(p) for p in players]
-    new_tile = move_robber(board, choose_place_robber(board, players_public, player))
+    new_tile = BoardApi.move_robber(board, choose_place_robber(board, players_public, player))
     potential_victims = get_potential_theft_victims(board, players, player, new_tile)
     if length(potential_victims) > 0
         chosen_victim = choose_robber_victim(board, player, potential_victims...)
@@ -286,7 +286,7 @@ end
 
 function do_robber_move(board, players::Vector{PlayerType}, player)
     players_public = [PlayerPublicView(p) for p in players]
-    new_tile = move_robber(board, choose_place_robber(board, players_public, player))
+    new_tile = BoardApi.move_robber(board, choose_place_robber(board, players_public, player))
     @info "$(player.player.team) moves robber to $new_tile"
     for p in players
         
@@ -388,7 +388,7 @@ function someone_has_won(game, board, players::Vector{PlayerType})::Bool
     return get_winner(game, board, players) != nothing
 end
 function get_winner(game, board, players::Vector{PlayerType})::Union{Nothing,PlayerType}
-    board_points = count_victory_points_from_board(board) 
+    board_points = BoardApi.count_victory_points_from_board(board) 
     winner = nothing
     for player in players
         player_points = get_total_vp_count(board, player.player)
@@ -514,7 +514,7 @@ function print_player_stats(game, board, player::Player)
     public_points = get_public_vp_count(board, player)
     total_points = get_total_vp_count(board, player)
     @info "$(player.team) has $total_points points on turn $(game.turn_num) ($public_points points were public)"
-    print_board_stats()
+    BoardApi.print_board_stats(board, player.team)
     if player.has_largest_army
         @info "Largest Army ($(player.dev_cards_used[:Knight]) knights)"
     end

--- a/src/players/robot_player.jl
+++ b/src/players/robot_player.jl
@@ -22,15 +22,14 @@ function choose_accept_trade(board::Board, player::RobotPlayer, from_player::Pla
     return rand() > .5
 end
 
-function choose_road_location(board::Board, players::Vector{PlayerPublicView}, player::RobotPlayer, candidates::Vector{Tuple})::Union{Nothing,Vector{Tuple}}
-    candidates = get_admissible_road_locations(board, player.player, is_first_turn)
+function choose_road_location(board::Board, players::Vector{PlayerPublicView}, player::RobotPlayer, candidates::Vector{Vector{Tuple{Int, Int}}})::Union{Nothing,Vector{Tuple{Int, Int}}}
     if length(candidates) > 0
         return sample(candidates)
     end
     @info "I didn't find any place to put my road"
     return nothing
 end
-function choose_building_location(board::Board, players::Vector{PlayerPublicView}, player::RobotPlayer, candidates::Vector{Tuple{Int, Int}}, building_type::Symbol)::Union{Nothing,Vector{Tuple{Int,Int}}}
+function choose_building_location(board::Board, players::Vector{PlayerPublicView}, player::RobotPlayer, candidates::Vector{Tuple{Int, Int}}, building_type::Symbol)::Union{Nothing,Tuple{Int,Int}}
     if length(candidates) > 0
         return sample(candidates, 1)[1]
     end

--- a/src/players/robot_player.jl
+++ b/src/players/robot_player.jl
@@ -96,17 +96,17 @@ end
 
 function choose_next_action(board::Board, players::Vector{PlayerPublicView}, player::RobotPlayer, actions::Set{Symbol})
     if :ConstructCity in actions
-        candidates = get_admissible_city_locations(board, player.player.team)
+        candidates = BoardApi.get_admissible_city_locations(board, player.player.team)
         coord = choose_building_location(board, players::Vector{PlayerPublicView}, player, candidates, :City)
         return (g, b, p) -> construct_city(b, p.player, coord)
     end
     if :ConstructSettlement in actions
-        candidates = get_admissible_settlement_locations(board, player.player.team, false)
+        candidates = BoardApi.get_admissible_settlement_locations(board, player.player.team, false)
         coord = choose_building_location(board, players::Vector{PlayerPublicView}, player, candidates, :Settlement)
         return (g, b, p) -> construct_settlement(b, p.player, coord)
     end
     if :ConstructRoad in actions
-        candidates = get_admissible_road_locations(board, player.player.team, false)
+        candidates = BoardApi.get_admissible_road_locations(board, player.player.team, false)
         coord = choose_road_location(board, players::Vector{PlayerPublicView}, player, candidates)
         coord1 = coord[1]
         coord2 = coord[2]
@@ -150,19 +150,19 @@ function get_legal_action_functions(board::Board, players::Vector{PlayerPublicVi
     action_functions = []
     
     if :ConstructCity in actions
-        candidates = get_admissible_city_locations(board, player.player.team)
+        candidates = BoardApi.get_admissible_city_locations(board, player.player.team)
         for coord in candidates
             push!(action_functions, (g, b, p) -> construct_city(b, p.player, coord))
         end
     end
     if :ConstructSettlement in actions
-        candidates = get_admissible_settlement_locations(board, player.player.team)
+        candidates = BoardApi.get_admissible_settlement_locations(board, player.player.team)
         for coord in candidates
             push!(action_functions, (g, b, p) -> construct_settlement(b, p.player, coord))
         end
     end
     if :ConstructRoad in actions
-        candidates = get_admissible_road_locations(board, player.player.team)
+        candidates = BoardApi.get_admissible_road_locations(board, player.player.team)
         for coord in candidates
             push!(action_functions, (g, b, p) -> construct_road(b, p.player, coord[1], coord[2]))
         end

--- a/src/players/robot_player.jl
+++ b/src/players/robot_player.jl
@@ -96,17 +96,17 @@ end
 
 function choose_next_action(board::Board, players::Vector{PlayerPublicView}, player::RobotPlayer, actions::Set{Symbol})
     if :ConstructCity in actions
-        candidates = get_admissible_city_locations(board, player.player)
+        candidates = get_admissible_city_locations(board, player.player.team)
         coord = choose_building_location(board, players::Vector{PlayerPublicView}, player, candidates, :City)
         return (g, b, p) -> construct_city(b, p.player, coord)
     end
     if :ConstructSettlement in actions
-        candidates = get_admissible_settlement_locations(board, player.player, false)
+        candidates = get_admissible_settlement_locations(board, player.player.team, false)
         coord = choose_building_location(board, players::Vector{PlayerPublicView}, player, candidates, :Settlement)
         return (g, b, p) -> construct_settlement(b, p.player, coord)
     end
     if :ConstructRoad in actions
-        candidates = get_admissible_road_locations(board, player.player, false)
+        candidates = get_admissible_road_locations(board, player.player.team, false)
         coord = choose_road_location(board, players::Vector{PlayerPublicView}, player, candidates)
         coord1 = coord[1]
         coord2 = coord[2]
@@ -150,19 +150,19 @@ function get_legal_action_functions(board::Board, players::Vector{PlayerPublicVi
     action_functions = []
     
     if :ConstructCity in actions
-        candidates = get_admissible_city_locations(board, player.player)
+        candidates = get_admissible_city_locations(board, player.player.team)
         for coord in candidates
             push!(action_functions, (g, b, p) -> construct_city(b, p.player, coord))
         end
     end
     if :ConstructSettlement in actions
-        candidates = get_admissible_settlement_locations(board, player.player)
+        candidates = get_admissible_settlement_locations(board, player.player.team)
         for coord in candidates
             push!(action_functions, (g, b, p) -> construct_settlement(b, p.player, coord))
         end
     end
     if :ConstructRoad in actions
-        candidates = get_admissible_road_locations(board, player.player)
+        candidates = get_admissible_road_locations(board, player.player.team)
         for coord in candidates
             push!(action_functions, (g, b, p) -> construct_road(b, p.player, coord[1], coord[2]))
         end

--- a/src/players/test_robot_player.jl
+++ b/src/players/test_robot_player.jl
@@ -54,9 +54,9 @@ end
 function choose_building_location(board::Board, players::Vector{PlayerPublicView}, player::TestRobotPlayer, building_type::Symbol, is_first_turn::Bool = false)::Tuple
     admissible = []
     if building_type == :Settlement
-        admissible = get_admissible_settlement_locations(board, player.player, is_first_turn)
+        admissible = get_admissible_settlement_locations(board, player.player.team, is_first_turn)
     else
-        admissible = get_admissible_city_locations(board, player.player)
+        admissible = get_admissible_city_locations(board, player.player.team)
     end
     return _get_optimal_building_placement(board, players, player, is_first_turn, admissible)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -513,7 +513,8 @@ function test_call_api()
     players_public = [PlayerPublicView(p) for p in players]
     
     # Build first settlement
-    loc_settlement = choose_building_location(board, players_public, player1, :Settlement, true)
+    candidates = get_admissible_settlement_locations(board, player1.player, true)
+    loc_settlement = choose_building_location(board, players_public, player1, candidates, :Settlement)
     @test loc_settlement != nothing
     build_settlement(board, player1.player.team, loc_settlement)
     settlement_locs = get_settlement_locations(board, player1.player.team)
@@ -521,14 +522,15 @@ function test_call_api()
     
     # Upgrade it to a city
     players_public = [PlayerPublicView(p) for p in players]
-    loc_city = choose_building_location(board, players_public, player1, :City)
+    candidates = get_admissible_city_locations(board, player1.player)
+    loc_city = choose_building_location(board, players_public, player1, candidates, :City)
     build_city(board, player1.player.team, loc_city)
     @test loc_settlement == loc_city
     
     # Build a road attached to first settlement
     players_public = [PlayerPublicView(p) for p in players]
-    admissible_roads = get_admissible_road_locations(board, player1.player)
-    road_coords = choose_road_location(board, players_public, player1)
+    admissible_roads = get_admissible_road_locations(board, player1.player, true)
+    road_coords = choose_road_location(board, players_public, player1, admissible_roads)
     build_road(board, player1.player.team, road_coords[1], road_coords[2])
     @test length(admissible_roads) == length(get_neighbors(loc_settlement))
     @test (road_coords[1] == loc_settlement || road_coords[2] == loc_settlement)
@@ -536,7 +538,8 @@ function test_call_api()
 
     # Build second settlement
     players_public = [PlayerPublicView(p) for p in players]
-    loc_settlement = choose_building_location(board, players_public, player1, :Settlement, true)
+    candidates = get_admissible_settlement_locations(board, player1.player, true)
+    loc_settlement = choose_building_location(board, players_public, player1, candidates, :Settlement)
     @test loc_settlement != nothing
     build_settlement(board, player1.player.team, loc_settlement)
     settlement_locs = get_settlement_locations(board, player1.player.team)
@@ -545,7 +548,7 @@ function test_call_api()
     # Build a road attached to second settlement
     admissible_roads = get_admissible_road_locations(board, player1.player, true)
     players_public = [PlayerPublicView(p) for p in players]
-    road_coords = choose_road_location(board, players_public, player1, true)
+    road_coords = choose_road_location(board, players_public, player1, admissible_roads)
     if road_coords == nothing
         print_board(board)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ play_devcard,
 assign_largest_army!,
 get_total_vp_count,
 add_port,
-BoardApi
+get_potential_theft_victims
 
 
 TEST_DATA_DIR = "data/"
@@ -258,20 +258,20 @@ function test_robber()
     BoardApi.build_settlement(board, :Test1, (1,1))
     BoardApi.build_settlement(board, :Test2, (1,3))
 
-    victims = Catan.get_potential_theft_victims(board, players, player1, :A)
+    victims = get_potential_theft_victims(board, players, player1, :A)
     @test length(victims) == 0
     
-    victims = Catan.get_potential_theft_victims(board, players, player1, :S)
+    victims = get_potential_theft_victims(board, players, player1, :S)
     @test length(victims) == 0
 
     Catan.give_resource(player2.player, :Grain)
     
-    victims = Catan.get_potential_theft_victims(board, players, player1, :A)
+    victims = get_potential_theft_victims(board, players, player1, :A)
     @test length(victims) == 1
     
     Catan.take_resource(player2.player, :Grain)
     
-    victims = Catan.get_potential_theft_victims(board, players, player1, :A)
+    victims = get_potential_theft_victims(board, players, player1, :A)
     @test length(victims) == 0
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,17 @@
 using Test
-#using Dates
-#using Logging
+using Dates
+using Logging
 #using Catan
-include("../src/main.jl")
+#include("../src/Catan.jl")
+#include("../src/main.jl")
+using Catan
+using Catan: DefaultRobotPlayer, RobotPlayer, Player, Board, PlayerType, PlayerPublicView, Game,
+    initialize_and_do_game!,
+get_coord_from_human_tile_description,
+get_road_coords_from_human_tile_description,
+get_neighbors,
+Board,
+Road
 
 TEST_DATA_DIR = "data/"
 MAIN_DATA_DIR = "../data/"
@@ -24,11 +33,13 @@ global_logger(logger)
 
 global counter = 1
 
+"""
 function reset_savefile(file_name)
     global SAVEFILE = file_name
     global SAVEFILEIO = open(SAVEFILE, "a")
     return SAVEFILE, SAVEFILEIO
 end
+"""
 
 function reset_savefile_with_timestamp(name)
     global SAVEFILE = "data/_$(name)_$(Dates.format(now(), "yyyymmdd_HHMMSS"))_$counter.txt"
@@ -69,7 +80,7 @@ function test_set_starting_player()
     players = setup_players(team_and_playertype)
     game = Game(players)
 
-    set_starting_player(game, 2)
+    Catan.set_starting_player(game, 2)
 
     @test game.turn_order_set == true
     @test game.players[1].player.team == :cyan
@@ -82,6 +93,7 @@ function test_set_starting_player()
     @info "testing logfile $SAVEFILE"
     new_game = Game(players)
     load_gamestate!(new_game, board, SAVEFILE)
+    println("save file: $SAVEFILE")
     
     flush(logger_io)
 
@@ -573,44 +585,44 @@ end
 
 
 function test_assign_largest_army()
-    board = read_map(SAMPLE_MAP)
-    player_blue = DefaultRobotPlayer(:Blue)
+    board = Catan.read_map(SAMPLE_MAP)
+    player_blue = Catan.DefaultRobotPlayer(:Blue)
     player_green = DefaultRobotPlayer(:Green)
     players = Vector{PlayerType}([player_blue, player_green])
 
     @test player_blue.player.has_largest_army == false
     @test player_green.player.has_largest_army == false
 
-    _add_devcard(player_blue.player, :Knight)
-    _add_devcard(player_blue.player, :Knight)
-    _add_devcard(player_blue.player, :Knight)
-    _play_devcard(player_blue.player, :Knight)
-    _play_devcard(player_blue.player, :Knight)
-    assign_largest_army!(players)
+    Catan._add_devcard(player_blue.player, :Knight)
+    Catan._add_devcard(player_blue.player, :Knight)
+    Catan._add_devcard(player_blue.player, :Knight)
+    Catan._play_devcard(player_blue.player, :Knight)
+    Catan._play_devcard(player_blue.player, :Knight)
+    Catan.assign_largest_army!(players)
 
     @test player_blue.player.has_largest_army == false
     @test player_green.player.has_largest_army == false
 
-    _play_devcard(player_blue.player, :Knight)
-    assign_largest_army!(players)
+    Catan._play_devcard(player_blue.player, :Knight)
+    Catan.assign_largest_army!(players)
     
     @test player_blue.player.has_largest_army == true
     @test player_green.player.has_largest_army == false
     
-    _add_devcard(player_green.player, :Knight)
-    _add_devcard(player_green.player, :Knight)
-    _add_devcard(player_green.player, :Knight)
-    _play_devcard(player_green.player, :Knight)
-    _play_devcard(player_green.player, :Knight)
-    _play_devcard(player_green.player, :Knight)
-    assign_largest_army!(players)
+    Catan._add_devcard(player_green.player, :Knight)
+    Catan._add_devcard(player_green.player, :Knight)
+    Catan._add_devcard(player_green.player, :Knight)
+    Catan._play_devcard(player_green.player, :Knight)
+    Catan._play_devcard(player_green.player, :Knight)
+    Catan._play_devcard(player_green.player, :Knight)
+    Catan.assign_largest_army!(players)
 
     @test player_blue.player.has_largest_army == true
     @test player_green.player.has_largest_army == false
 
-    _add_devcard(player_green.player, :Knight)
-    _play_devcard(player_green.player, :Knight)
-    assign_largest_army!(players)
+    Catan._add_devcard(player_green.player, :Knight)
+    Catan._play_devcard(player_green.player, :Knight)
+    Catan.assign_largest_army!(players)
     
     # TODO fails
     println(player_blue.player)
@@ -674,6 +686,7 @@ function run_tests(neverend = false)
     """
     """
 end
+println("abspath(PROGRAM_FILE): $(abspath(PROGRAM_FILE))")
 if abspath(PROGRAM_FILE) == @__FILE__
     if (length(ARGS) > 0)
         if ARGS[1] == "--neverend"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,13 +5,21 @@ using Logging
 #include("../src/Catan.jl")
 #include("../src/main.jl")
 using Catan
-using Catan: DefaultRobotPlayer, RobotPlayer, Player, Board, PlayerType, PlayerPublicView, Game,
-    initialize_and_do_game!,
+using Catan: 
 get_coord_from_human_tile_description,
 get_road_coords_from_human_tile_description,
 get_neighbors,
-Board,
-Road
+read_map,
+load_gamestate!,
+reset_savefile,
+random_sample_resources,
+add_devcard,
+play_devcard,
+assign_largest_army!,
+get_total_vp_count,
+add_port,
+BoardApi
+
 
 TEST_DATA_DIR = "data/"
 MAIN_DATA_DIR = "../data/"
@@ -19,7 +27,6 @@ MAIN_DATA_DIR = "../data/"
 SAVEFILE = "$(TEST_DATA_DIR)_test_save_$(Dates.format(now(), "HHMMSS")).txt"
 reset_savefile(SAVEFILE)
 
-#Catan.SAVE_GAME_TO_FILE = false
 Catan.SAVE_GAME_TO_FILE = true
 
 SAMPLE_MAP = "$(MAIN_DATA_DIR)sample.csv"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,8 +17,11 @@ TEST_DATA_DIR = "data/"
 MAIN_DATA_DIR = "../data/"
 
 SAVEFILE = "$(TEST_DATA_DIR)_test_save_$(Dates.format(now(), "HHMMSS")).txt"
-SAVEFILEIO = open(SAVEFILE, "a")
-SAVE_GAME_TO_FILE = true
+reset_savefile(SAVEFILE)
+
+#Catan.SAVE_GAME_TO_FILE = false
+Catan.SAVE_GAME_TO_FILE = true
+
 SAMPLE_MAP = "$(MAIN_DATA_DIR)sample.csv"
 println(SAVEFILE)
 
@@ -33,19 +36,17 @@ global_logger(logger)
 
 global counter = 1
 
-"""
-function reset_savefile(file_name)
+function reset_test_savefile(file_name)
     global SAVEFILE = file_name
-    global SAVEFILEIO = open(SAVEFILE, "a")
-    return SAVEFILE, SAVEFILEIO
+    reset_savefile(file_name)
+    return SAVEFILE, Catan.SAVEFILEIO
 end
-"""
 
 function reset_savefile_with_timestamp(name)
     global SAVEFILE = "data/_$(name)_$(Dates.format(now(), "yyyymmdd_HHMMSS"))_$counter.txt"
     global counter += 1
-    global SAVEFILEIO = open(SAVEFILE, "a")
-    return SAVEFILE, SAVEFILEIO
+    reset_savefile(SAVEFILE)
+    return SAVEFILE, Catan.SAVEFILEIO
 end
 
 function test_actions()
@@ -70,7 +71,8 @@ function test_deepcopy()
 end
 
 function test_set_starting_player()
-    reset_savefile_with_timestamp("test_set_starting_player")
+    sf, sfio = reset_savefile_with_timestamp("test_set_starting_player")
+    reset_savefile(sf, sfio)
     team_and_playertype = [
                           (:blue, DefaultRobotPlayer),
                           (:cyan, DefaultRobotPlayer),
@@ -88,12 +90,11 @@ function test_set_starting_player()
     @test game.players[3].player.team == :red
     @test game.players[4].player.team == :blue
     
-    flush(SAVEFILEIO)
+    flush(Catan.SAVEFILEIO)
     board = read_map(SAMPLE_MAP)
     @info "testing logfile $SAVEFILE"
     new_game = Game(players)
     load_gamestate!(new_game, board, SAVEFILE)
-    println("save file: $SAVEFILE")
     
     flush(logger_io)
 
@@ -145,7 +146,7 @@ function setup_and_do_robot_game(players::Vector{PlayerType}, savefile::Union{No
     if (savefile == nothing)
         reset_savefile_with_timestamp("test_robot_game_savefile")
     else
-        reset_savefile(savefile)
+        reset_test_savefile(savefile)
     end
     board, winner = initialize_and_do_game!(game, SAMPLE_MAP)
     return board, game
@@ -199,7 +200,7 @@ function test_log()
                           (:red, DefaultRobotPlayer)
                          ]
     board, game = setup_and_do_robot_game(team_and_playertype)
-    flush(SAVEFILEIO)
+    flush(Catan.SAVEFILEIO)
     
     @info "testing savefile $SAVEFILE"
     
@@ -237,9 +238,9 @@ function test_do_turn()
     player2 = DefaultRobotPlayer(:Test2)
     players = Vector{PlayerType}([player1, player2])
     game = Game(players)
-    start_turn(game)
+    Catan.start_turn(game)
     @test game.turn_num == 1
-    do_turn(game, board, player1)
+    Catan.do_turn(game, board, player1)
 end
 
 function test_robber()
@@ -247,23 +248,23 @@ function test_robber()
     player1 = DefaultRobotPlayer(:Test1)
     player2 = DefaultRobotPlayer(:Test2)
     players = Vector{PlayerType}([player1, player2])
-    build_settlement(board, :Test1, (1,1))
-    build_settlement(board, :Test2, (1,3))
+    BoardApi.build_settlement(board, :Test1, (1,1))
+    BoardApi.build_settlement(board, :Test2, (1,3))
 
-    victims = get_potential_theft_victims(board, players, player1, :A)
+    victims = Catan.get_potential_theft_victims(board, players, player1, :A)
     @test length(victims) == 0
     
-    victims = get_potential_theft_victims(board, players, player1, :S)
+    victims = Catan.get_potential_theft_victims(board, players, player1, :S)
     @test length(victims) == 0
 
-    give_resource(player2.player, :Grain)
+    Catan.give_resource(player2.player, :Grain)
     
-    victims = get_potential_theft_victims(board, players, player1, :A)
+    victims = Catan.get_potential_theft_victims(board, players, player1, :A)
     @test length(victims) == 1
     
-    take_resource(player2.player, :Grain)
+    Catan.take_resource(player2.player, :Grain)
     
-    victims = get_potential_theft_victims(board, players, player1, :A)
+    victims = Catan.get_potential_theft_victims(board, players, player1, :A)
     @test length(victims) == 0
 end
 
@@ -271,30 +272,30 @@ function test_max_construction()
     board = read_map(SAMPLE_MAP)
     player1 = DefaultRobotPlayer(:Test1)
     for i in 1:(MAX_SETTLEMENT-1)
-        build_settlement(board, :Test1, get_admissible_settlement_locations(board, player1.player.team, true)[1])
+        BoardApi.build_settlement(board, :Test1, BoardApi.get_admissible_settlement_locations(board, player1.player.team, true)[1])
     end
-    @test length(get_admissible_settlement_locations(board, player1.player.team, true)) > 0
-    build_settlement(board, :Test1, get_admissible_settlement_locations(board, player1.player.team, true)[1])
-    @test length(get_admissible_settlement_locations(board, player1.player.team, true)) == 0
-    @test count_settlements(board, player1.player.team) == MAX_SETTLEMENT
+    @test length(BoardApi.get_admissible_settlement_locations(board, player1.player.team, true)) > 0
+    BoardApi.build_settlement(board, :Test1, BoardApi.get_admissible_settlement_locations(board, player1.player.team, true)[1])
+    @test length(BoardApi.get_admissible_settlement_locations(board, player1.player.team, true)) == 0
+    @test BoardApi.count_settlements(board, player1.player.team) == MAX_SETTLEMENT
     
     for i in 1:(MAX_CITY-1)
-        build_city(board, :Test1, get_admissible_city_locations(board, player1.player.team)[1])
+        BoardApi.build_city(board, :Test1, BoardApi.get_admissible_city_locations(board, player1.player.team)[1])
     end
-    @test length(get_admissible_city_locations(board, player1.player.team)) > 0
-    build_city(board, :Test1, get_admissible_city_locations(board, player1.player.team)[1])
-    @test length(get_admissible_city_locations(board, player1.player.team)) == 0
-    @test count_cities(board, player1.player.team) == MAX_CITY
+    @test length(BoardApi.get_admissible_city_locations(board, player1.player.team)) > 0
+    BoardApi.build_city(board, :Test1, BoardApi.get_admissible_city_locations(board, player1.player.team)[1])
+    @test length(BoardApi.get_admissible_city_locations(board, player1.player.team)) == 0
+    @test BoardApi.count_cities(board, player1.player.team) == MAX_CITY
     
     for i in 1:(MAX_ROAD-1)
-        coords = get_admissible_road_locations(board, player1.player.team)[1]
-        build_road(board, :Test1, coords...)
+        coords = BoardApi.get_admissible_road_locations(board, player1.player.team)[1]
+        BoardApi.build_road(board, :Test1, coords...)
     end
-    @test length(get_admissible_road_locations(board, player1.player.team)) > 0
-    coords = get_admissible_road_locations(board, player1.player.team)[1]
-    build_road(board, :Test1, coords...)
-    @test length(get_admissible_road_locations(board, player1.player.team)) == 0
-    @test count_roads(board, player1.player.team) == MAX_ROAD
+    @test length(BoardApi.get_admissible_road_locations(board, player1.player.team)) > 0
+    coords = BoardApi.get_admissible_road_locations(board, player1.player.team)[1]
+    BoardApi.build_road(board, :Test1, coords...)
+    @test length(BoardApi.get_admissible_road_locations(board, player1.player.team)) == 0
+    @test BoardApi.count_roads(board, player1.player.team) == MAX_ROAD
 end
 
 # API Tests
@@ -304,27 +305,27 @@ function test_devcards()
     player2 = DefaultRobotPlayer(:Test2)
     players = Vector{PlayerType}([player1, player2])
 
-    give_resource(player1.player, :Grain)
-    give_resource(player1.player, :Stone)
-    give_resource(player1.player, :Pasture)
-    give_resource(player1.player, :Brick)
-    give_resource(player1.player, :Wood)
+    Catan.give_resource(player1.player, :Grain)
+    Catan.give_resource(player1.player, :Stone)
+    Catan.give_resource(player1.player, :Pasture)
+    Catan.give_resource(player1.player, :Brick)
+    Catan.give_resource(player1.player, :Wood)
     
-    do_monopoly_action(board, players, player2)
-    @test count_resources(player1.player) == 4
+    Catan.do_monopoly_action(board, players, player2)
+    @test Catan.count_resources(player1.player) == 4
     
     players_public = [PlayerPublicView(p) for p in players]
-    do_year_of_plenty_action(board, players_public, player1)
-    @test count_resources(player1.player) == 6
+    Catan.do_year_of_plenty_action(board, players_public, player1)
+    @test Catan.count_resources(player1.player) == 6
 
-    build_settlement(board, player1.player.team, (2,5))
+    BoardApi.build_settlement(board, player1.player.team, (2,5))
     players_public = [PlayerPublicView(p) for p in players]
-    do_road_building_action(board, players_public, player1)
-    @test count_roads(board, player1.player.team) == 2
+    Catan.do_road_building_action(board, players_public, player1)
+    @test BoardApi.count_roads(board, player1.player.team) == 2
     
     players_public = [PlayerPublicView(p) for p in players]
-    do_road_building_action(board, players_public, player1)
-    @test count_roads(board, player1.player.team) == 4
+    Catan.do_road_building_action(board, players_public, player1)
+    @test BoardApi.count_roads(board, player1.player.team) == 4
     
     @test get_total_vp_count(board, player1.player) == 1
     @test get_total_vp_count(board, player2.player) == 0
@@ -393,44 +394,44 @@ function test_longest_road()
     # (9)|  D  |  E  |  F  |  G  |
     #    21-22-23-24-25-26-27-28-29
     
-    build_settlement(board, :Green, (2,4))
-    build_settlement(board, :Blue, (2,3))
+    BoardApi.build_settlement(board, :Green, (2,4))
+    BoardApi.build_settlement(board, :Blue, (2,3))
 
-    build_road(board, :Blue, (2,3), (2,4))
-    build_road(board, :Blue, (2,2), (2,3))
-    build_road(board, :Blue, (2,1), (2,2))
-    build_road(board, :Blue, (2,1), (3,2))
+    BoardApi.build_road(board, :Blue, (2,3), (2,4))
+    BoardApi.build_road(board, :Blue, (2,2), (2,3))
+    BoardApi.build_road(board, :Blue, (2,1), (2,2))
+    BoardApi.build_road(board, :Blue, (2,1), (3,2))
 
     @test board.longest_road == nothing
     
     
     # Length 5 road, but it's intersected by :Green settlement
-    build_road(board, :Blue, (2,5), (2,4))
+    BoardApi.build_road(board, :Blue, (2,5), (2,4))
     @test board.longest_road == nothing
 
     # Now player one builds a 5-length road without intersection
-    build_road(board, :Blue, (3,3), (3,2))
+    BoardApi.build_road(board, :Blue, (3,3), (3,2))
     @test board.longest_road == :Blue
 
-    build_settlement(board, :Green, (3,10))
-    build_road(board, :Green, (3,10), (3,11))
-    build_road(board, :Green, (3,10), (3,9))
-    build_road(board, :Green, (3,8), (3,9))
-    build_road(board, :Green, (3,10), (2,9))
-    build_road(board, :Green, (2,9), (2,8))
-    build_road(board, :Green, (2,8), (2,7))
+    BoardApi.build_settlement(board, :Green, (3,10))
+    BoardApi.build_road(board, :Green, (3,10), (3,11))
+    BoardApi.build_road(board, :Green, (3,10), (3,9))
+    BoardApi.build_road(board, :Green, (3,8), (3,9))
+    BoardApi.build_road(board, :Green, (3,10), (2,9))
+    BoardApi.build_road(board, :Green, (2,9), (2,8))
+    BoardApi.build_road(board, :Green, (2,8), (2,7))
     
     # Player green built 6 roads connected, but branched, so still player 1 has longest road
     @test board.longest_road == :Blue
     
     # Now player green makes a loop, allowing 6 roads continuous
-    build_road(board, :Green, (3,8), (2,7))
+    BoardApi.build_road(board, :Green, (3,8), (2,7))
     @test board.longest_road == :Green
 
-    build_settlement(board, :Blue, (5,1))
-    build_road(board, :Blue, (5,1), (5,2))
-    build_road(board, :Blue, (5,3), (5,2))
-    build_road(board, :Blue, (5,3), (5,4))
+    BoardApi.build_settlement(board, :Blue, (5,1))
+    BoardApi.build_road(board, :Blue, (5,1), (5,2))
+    BoardApi.build_road(board, :Blue, (5,3), (5,2))
+    BoardApi.build_road(board, :Blue, (5,3), (5,4))
     
     # Player blue added more roads, but not contiguous, so they don't beat player green
     @test board.longest_road == :Green
@@ -461,7 +462,7 @@ function test_ports()
     @test player1.player.ports[:Grain] == 2
     @test player1.player.ports[:Wood] == 3
 
-    construct_settlement(board, player1.player, (3,2))
+    Catan.construct_settlement(board, player1.player, (3,2))
     
     @test player1.player.ports[:Brick] == 2
 end
@@ -483,27 +484,27 @@ function test_board_api()
     @test length(get_neighbors((4,1))) == 2
 
     board = read_map(SAMPLE_MAP)
-    build_settlement(board, :Test1, (1,1))
-    build_road(board, :Test1, (1,1),(1,2))
-    @test is_valid_settlement_placement(board, :Test1, (1,2)) == false
-    build_settlement(board, :Test1, (1,2))
+    BoardApi.build_settlement(board, :Test1, (1,1))
+    BoardApi.build_road(board, :Test1, (1,1),(1,2))
+    @test BoardApi.is_valid_settlement_placement(board, :Test1, (1,2)) == false
+    BoardApi.build_settlement(board, :Test1, (1,2))
 
-    build_settlement(board, :Test1, (3,9))
-    @test is_valid_settlement_placement(board, :Test1, (4,9)) == false
-    @test !((4,9) in get_admissible_settlement_locations(board, :Test1, true))
+    BoardApi.build_settlement(board, :Test1, (3,9))
+    @test BoardApi.is_valid_settlement_placement(board, :Test1, (4,9)) == false
+    @test !((4,9) in BoardApi.get_admissible_settlement_locations(board, :Test1, true))
 
     @test length(board.buildings) == 3
     @test length(keys(board.coord_to_building)) == 3
-    @test count_settlements(board, :Test1) == 3
-    @test count_settlements(board, :Test2) == 0
+    @test BoardApi.count_settlements(board, :Test1) == 3
+    @test BoardApi.count_settlements(board, :Test2) == 0
 
-    build_city(board, :Test1, (1,1))
+    BoardApi.build_city(board, :Test1, (1,1))
     @test length(board.buildings) == 3
     @test length(keys(board.coord_to_building)) == 3
-    @test count_settlements(board, :Test1) == 2
-    @test count_cities(board, :Test1) == 1
-    @test count_settlements(board, :Test2) == 0
-    @test count_victory_points_from_board(board, :Test1) == 4
+    @test BoardApi.count_settlements(board, :Test1) == 2
+    @test BoardApi.count_cities(board, :Test1) == 1
+    @test BoardApi.count_settlements(board, :Test2) == 0
+    @test BoardApi.count_victory_points_from_board(board, :Test1) == 4
 end
 
 function test_call_api()
@@ -512,31 +513,31 @@ function test_call_api()
     player2 = DefaultRobotPlayer(:Test2)
     players = Vector{PlayerType}([player1, player2])
 
-    @test has_any_resources(player1.player) == false
-    @test has_any_resources(player2.player) == false
+    @test Catan.has_any_resources(player1.player) == false
+    @test Catan.has_any_resources(player2.player) == false
 
-    give_resource(player1.player, :Grain)
+    Catan.give_resource(player1.player, :Grain)
 
-    @test has_any_resources(player1.player) == true
+    @test Catan.has_any_resources(player1.player) == true
 
-    @test roll_dice(player1) <= 12
-    @test roll_dice(player2) >= 2
+    @test Catan.roll_dice(player1) <= 12
+    @test Catan.roll_dice(player2) >= 2
     
     players_public = [PlayerPublicView(p) for p in players]
     
     # Build first settlement
-    settlement = choose_validate_build_settlement(board, players_public, player1, true)
+    settlement = Catan.choose_validate_build_settlement(board, players_public, player1, true)
     loc_settlement = settlement.coord
     #candidates = get_admissible_settlement_locations(board, player1.player.team, true)
     #loc_settlement = choose_building_location(board, players_public, player1, candidates, :Settlement)
     #build_settlement(board, player1.player.team, loc_settlement)
     @test loc_settlement != nothing
-    settlement_locs = get_settlement_locations(board, player1.player.team)
+    settlement_locs = BoardApi.get_settlement_locations(board, player1.player.team)
     @test length(settlement_locs) == 1
     
     # Upgrade it to a city
     players_public = [PlayerPublicView(p) for p in players]
-    city = choose_validate_build_city(board, players_public, player1)
+    city = Catan.choose_validate_build_city(board, players_public, player1)
     loc_city = city.coord
     #candidates = get_admissible_city_locations(board, player1.player.team)
     #loc_city = choose_building_location(board, players_public, player1, candidates, :City)
@@ -547,30 +548,30 @@ function test_call_api()
     players_public = [PlayerPublicView(p) for p in players]
     
     #Equiv: choose_validate_build_road(board, players_public, player1, true)
-    admissible_roads = get_admissible_road_locations(board, player1.player.team, true)
-    road_coords = choose_road_location(board, players_public, player1, admissible_roads)
-    build_road(board, player1.player.team, road_coords[1], road_coords[2])
-    @test length(admissible_roads) == length(get_neighbors(loc_settlement))
+    admissible_roads = BoardApi.get_admissible_road_locations(board, player1.player.team, true)
+    road_coords = Catan.choose_road_location(board, players_public, player1, admissible_roads)
+    BoardApi.build_road(board, player1.player.team, road_coords[1], road_coords[2])
+    @test length(admissible_roads) == length(BoardApi.get_neighbors(loc_settlement))
     @test (road_coords[1] == loc_settlement || road_coords[2] == loc_settlement)
-    @test length(get_road_locations(board, player1.player.team)) == 2
+    @test length(BoardApi.get_road_locations(board, player1.player.team)) == 2
 
     # Build second settlement
     players_public = [PlayerPublicView(p) for p in players]
-    settlement = choose_validate_build_settlement(board, players_public, player1, true)
+    settlement = Catan.choose_validate_build_settlement(board, players_public, player1, true)
     loc_settlement = settlement.coord
     @test loc_settlement != nothing
-    settlement_locs = get_settlement_locations(board, player1.player.team)
+    settlement_locs = BoardApi.get_settlement_locations(board, player1.player.team)
     @test length(settlement_locs) == 1 # City is no longer counted
     
     # Build a road attached to second settlement
-    admissible_roads = get_admissible_road_locations(board, player1.player.team, true)
+    admissible_roads = BoardApi.get_admissible_road_locations(board, player1.player.team, true)
     players_public = [PlayerPublicView(p) for p in players]
-    road_coords = choose_road_location(board, players_public, player1, admissible_roads)
+    road_coords = Catan.choose_road_location(board, players_public, player1, admissible_roads)
     if road_coords == nothing
         print_board(board)
     end
-    build_road(board, player1.player.team, road_coords[1], road_coords[2])
-    @test length(admissible_roads) == length(get_neighbors(loc_settlement))
+    BoardApi.build_road(board, player1.player.team, road_coords[1], road_coords[2])
+    @test length(admissible_roads) == length(BoardApi.get_neighbors(loc_settlement))
     @test (road_coords[1] == loc_settlement || road_coords[2] == loc_settlement)
 
 # roll_dice(player::RobotPlayer)::Int
@@ -686,7 +687,6 @@ function run_tests(neverend = false)
     """
     """
 end
-println("abspath(PROGRAM_FILE): $(abspath(PROGRAM_FILE))")
 if abspath(PROGRAM_FILE) == @__FILE__
     if (length(ARGS) > 0)
         if ARGS[1] == "--neverend"


### PR DESCRIPTION
Creates first sub-module, `BoardApi` to hold all read-write operations pertaining to the game board.
The advantage of submodules is that the namespace is divided into logical divisions, so the code is easier to follow, and the dependencies are better documented and enforced by the code itself:
```
using ..Catan: Board, Building, Road, log_action, 
MAX_ROAD, MAX_SETTLEMENT, MAX_CITY, DIMS, COORD_TO_TILES, VP_AWARDS
include("../board.jl")

```
this shows that `Catan.BoardApi` only requires two structs from outside (`Building` and `Road`), one method, and some constants.  Additionally, it includes the whole of `board.jl` in its module, and `board.jl` isn't included anywhere else.